### PR TITLE
fixed signup page firstName validation to only display helperText if input fails validation

### DIFF
--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -34,7 +34,7 @@ const SignupPage = () => {
                   required
                   autoFocus
                   color="primary"
-                  error={errors && errors.firstName}
+                  error={!!errors.firstName}
                   helperText={errors.firstName?.message}
                   variant="outlined"
                   id="firstName"

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -34,8 +34,8 @@ const SignupPage = () => {
                   required
                   autoFocus
                   color="primary"
-                  error={!!errors.firstName}
-                  helperText="First Name is required"
+                  error={errors && errors.firstName}
+                  helperText={errors.firstName?.message}
                   variant="outlined"
                   id="firstName"
                   name="firstName"


### PR DESCRIPTION
**What it does**

1. Corrects the signup page which previously displayed the validation error on initial page render