### PR TITLE
FE: Add Dialog component for #12

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -2,4 +2,3 @@
 .vscode/
 
 node_modules/
-package-lock.json

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 
 node_modules/
+package-lock.json

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@material-ui/icons": "^4.9.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-google-button": "^0.7.1",
     "react-hook-form": "^6.9.2",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.4.3"

--- a/client/src/components/Dialog.jsx
+++ b/client/src/components/Dialog.jsx
@@ -1,0 +1,77 @@
+// this component will eventually be rendered in the Dashboard page
+
+import React from "react";
+import GoogleButton from "react-google-button";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+
+// these will eventually be accessed from UserContext and passed down as props
+// e.g. AlertDialog({ emailAuth, title, bodyText, buttonText }) {
+//     ...
+// }
+const emailAuth = false;
+const title = "Connect a Gmail Account";
+const bodyText =
+  "Connect a Gmail account to access all of MailSender's features.";
+const buttonText = "Skip";
+
+export default function AlertDialog() {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(!open);
+  };
+
+  React.useEffect(() => {
+    // open after 2s for smoother experience
+    const timer = setTimeout(() => {
+      if (!emailAuth) {
+        handleOpen();
+      }
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            {bodyText}
+          </DialogContentText>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+            }}
+          >
+            <GoogleButton
+              onClick={() => {
+                console.log("Google button clicked");
+              }}
+            />
+          </div>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color={"primary"}>
+            {buttonText}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
**What it does**
- Creates a Dialog component for use in Gmail authentication flow on Dashboard page ( see #12 ). 
- Adds dependency [react-google-button](https://www.npmjs.com/package/react-google-button). 

**What to look for**
- Try testing it by rendering it within a `/dialog` route in App.jsx.
- It may need to be modified later on for use within the Dashboard page. 

**What to avoid**
- Don't add any props, as dummy props are used. We'll be grabbing the actual props from UserContext later on. 