### PR TITLE
Move config args to config.py from app.py 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,5 @@ instance/
 # VSCode
 .vscode
 
-
-#TODO add .env to your gitignore
+.env
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,3 @@ instance/
 
 # VSCode
 .vscode
-
-.env
-

--- a/server/.env
+++ b/server/.env
@@ -7,4 +7,5 @@ DB_ADDR = "" # Your mongodb addr
 
 JWT_SECRET_KEY = "VkO\xce\x0b\xc8\xde\xf1l\xaaQ+\x8bT\xfa\xbf\xb4\xf7\xdf\xc3OP\xcb\x86"  # This secret is for test
 
-# git update-index --assume-unchanged ./.env
+# Run `git update-index --assume-unchanged ./.env` to prevent .env from git commit
+# `git update-index --no-assume-unchanged ./.env` can cancel it.

--- a/server/.env
+++ b/server/.env
@@ -1,3 +1,10 @@
 TEAM_NAME="Shums,StevenM,Boting,Carrie"
 
 FLASK_ENV="development"
+DEBUG = True
+
+DB_ADDR = "" # Your mongodb addr
+
+JWT_SECRET_KEY = "VkO\xce\x0b\xc8\xde\xf1l\xaaQ+\x8bT\xfa\xbf\xb4\xf7\xdf\xc3OP\xcb\x86"  # This secret is for test
+
+# git update-index --assume-unchanged ./.env

--- a/server/Pipfile
+++ b/server/Pipfile
@@ -13,6 +13,7 @@ flask-bcrypt = "0.7.1"
 pymongo = {extras = ["srv"], version = "3.11.0"}
 flask-jwt-extended = "3.24.1"
 jsonschema = "3.2.0"
+python-dotenv = "0.14.0"
 
 [requires]
 python_version = "3.7"

--- a/server/Pipfile.lock
+++ b/server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "54429b98f86f399cd7e20518be3b4a5206029f0897427aefef9545f422b77a3c"
+            "sha256": "fecae96933991e32f8f81d68c809e0ea822b1ba969038d26f74a387c5ede4012"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -279,6 +279,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==0.17.3"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:8c10c99a1b25d9a68058a1ad6f90381a62ba68230ca93966882a4dbc3bc9c33d",
+                "sha256:c10863aee750ad720f4f43436565e4c1698798d763b63234fb5021b6c616e423"
+            ],
+            "index": "pypi",
+            "version": "==0.14.0"
         },
         "six": {
             "hashes": [

--- a/server/app.py
+++ b/server/app.py
@@ -8,32 +8,16 @@ from pymodm import connect
 import datetime
 import os
 
-DEV_mode = True
 app = Flask(__name__)
-
-app.config['JWT_TOKEN_LOCATION'] = ['cookies']  # Configure application to store JWTs in cookies
-app.config['JWT_COOKIE_SECURE'] = not DEV_mode  # Only allow JWT cookies to be sent over https.
-app.config['JWT_COOKIE_CSRF_PROTECT'] = False  # Enable csrf double submit protection. / False can pass the test.
-app.config['JWT_ACCESS_TOKEN_EXPIRES'] = datetime.timedelta(hours=5)    # JWT expire time
-app.config["JWT_ACCESS_CSRF_HEADER_NAME"] = "X-CSRF-TOKEN-ACCESS"
-app.config["JWT_REFRESH_CSRF_HEADER_NAME"] = "X-CSRF-TOKEN-REFRESH"
-# The secret is for test only
-app.config['JWT_SECRET_KEY'] = os.environ.get('SECRET',
-                                              b'VkO\xce\x0b\xc8\xde\xf1l\xaaQ+\x8bT\xfa\xbf\xb4\xf7\xdf\xc3OP\xcb\x86')
+app.config.from_object("config.DevConfig")
 
 bcrypt.init_app(app)
 jwt.init_app(app)
 
-default_db_alias = "user-db"
-db_addr = os.environ.get("db_addr", None)
-if DEV_mode:
-    # Your own mongodb address here
-    db_addr = "mongodb://localhost:27017/test_db"
-connect(db_addr, alias=os.environ.get("db_alias", default_db_alias))
+connect(app.config["DB_ADDR"], alias=app.config["DB_ALIAS"])
 
 app.register_blueprint(home_handler)
 app.register_blueprint(ping_handler)
 app.register_blueprint(register_handler)
 app.register_blueprint(auth_handler)
 
-# app.run()

--- a/server/app.py
+++ b/server/app.py
@@ -10,7 +10,6 @@ import os
 
 app = Flask(__name__)
 app.config.from_object("config.Config")
-print(app.config.get("ENV", 111))
 bcrypt.init_app(app)
 jwt.init_app(app)
 

--- a/server/app.py
+++ b/server/app.py
@@ -9,8 +9,8 @@ import datetime
 import os
 
 app = Flask(__name__)
-app.config.from_object("config.DevConfig")
-
+app.config.from_object("config.Config")
+print(app.config.get("ENV", 111))
 bcrypt.init_app(app)
 jwt.init_app(app)
 

--- a/server/app.py
+++ b/server/app.py
@@ -28,10 +28,7 @@ default_db_alias = "user-db"
 db_addr = os.environ.get("db_addr", None)
 if DEV_mode:
     # Your own mongodb address here
-    db_addr = "mongodb+srv://dbUser:{}BkA@{}.mongodb.net/db?retryWrites=true&w=majority".format(
-    "mqMgkPzs90L5x",
-    "cluster0.7p53t"
-)
+    db_addr = "mongodb://localhost:27017/test_db"
 connect(db_addr, alias=os.environ.get("db_alias", default_db_alias))
 
 app.register_blueprint(home_handler)

--- a/server/config.py
+++ b/server/config.py
@@ -2,32 +2,21 @@ import os
 import datetime
 from flask.cli import load_dotenv
 
-TEAM_NAME = os.environ.get('TEAM_NAME', "TEAM_AUTUMN")
-
 load_dotenv()
 
+TEAM_NAME = os.environ.get('TEAM_NAME', "TEAM_AUTUMN")
 
-class DevConfig:
-    TESTING = True
-    DEBUG = True
+
+class Config:
     JWT_TOKEN_LOCATION = ['cookies']  # Configure application to store JWTs in cookies
     JWT_COOKIE_SECURE = False  # Only allow JWT cookies to be sent over https.
     JWT_COOKIE_CSRF_PROTECT = False  # Enable csrf double submit protection. / False can pass the test.
     JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(hours=5)
     JWT_ACCESS_CSRF_HEADER_NAME = "X-CSRF-TOKEN-ACCESS"
     JWT_REFRESH_CSRF_HEADER_NAME = "X-CSRF-TOKEN-REFRESH"
-    JWT_SECRET_KEY = b'VkO\xce\x0b\xc8\xde\xf1l\xaaQ+\x8bT\xfa\xbf\xb4\xf7\xdf\xc3OP\xcb\x86'  # The secret is for test
-    DB_ADDR = os.environ.get("db_addr", None)  # Located at .env file
-    DB_ALIAS = "user-db"
 
-
-class ProdConfig:
-    JWT_TOKEN_LOCATION = ['cookies']  # Configure application to store JWTs in cookies
-    JWT_COOKIE_SECURE = True  # Only allow JWT cookies to be sent over https.
-    JWT_COOKIE_CSRF_PROTECT = True  # Enable csrf double submit protection. / False can pass the test.
-    JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(hours=5)
-    JWT_ACCESS_CSRF_HEADER_NAME = "X-CSRF-TOKEN-ACCESS"
-    JWT_REFRESH_CSRF_HEADER_NAME = "X-CSRF-TOKEN-REFRESH"
-    JWT_SECRET_KEY = os.getenv("jwt_secret_key", None)  # TODO: decode to bytes might be needed
-    DB_ADDR = ""
+    # Located at .env file
+    JWT_SECRET_KEY = bytes(os.environ.get("JWT_SECRET_KEY", ""), encoding="utf-8")\
+        .decode("unicode_escape").encode("latin-1")
+    DB_ADDR = os.environ.get("DB_ADDR", None)
     DB_ALIAS = "user-db"

--- a/server/config.py
+++ b/server/config.py
@@ -1,4 +1,33 @@
 import os
+import datetime
+from flask.cli import load_dotenv
 
 TEAM_NAME = os.environ.get('TEAM_NAME', "TEAM_AUTUMN")
 
+load_dotenv()
+
+
+class DevConfig:
+    TESTING = True
+    DEBUG = True
+    JWT_TOKEN_LOCATION = ['cookies']  # Configure application to store JWTs in cookies
+    JWT_COOKIE_SECURE = False  # Only allow JWT cookies to be sent over https.
+    JWT_COOKIE_CSRF_PROTECT = False  # Enable csrf double submit protection. / False can pass the test.
+    JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(hours=5)
+    JWT_ACCESS_CSRF_HEADER_NAME = "X-CSRF-TOKEN-ACCESS"
+    JWT_REFRESH_CSRF_HEADER_NAME = "X-CSRF-TOKEN-REFRESH"
+    JWT_SECRET_KEY = b'VkO\xce\x0b\xc8\xde\xf1l\xaaQ+\x8bT\xfa\xbf\xb4\xf7\xdf\xc3OP\xcb\x86'  # The secret is for test
+    DB_ADDR = os.environ.get("db_addr", None)  # Located at .env file
+    DB_ALIAS = "user-db"
+
+
+class ProdConfig:
+    JWT_TOKEN_LOCATION = ['cookies']  # Configure application to store JWTs in cookies
+    JWT_COOKIE_SECURE = True  # Only allow JWT cookies to be sent over https.
+    JWT_COOKIE_CSRF_PROTECT = True  # Enable csrf double submit protection. / False can pass the test.
+    JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(hours=5)
+    JWT_ACCESS_CSRF_HEADER_NAME = "X-CSRF-TOKEN-ACCESS"
+    JWT_REFRESH_CSRF_HEADER_NAME = "X-CSRF-TOKEN-REFRESH"
+    JWT_SECRET_KEY = os.getenv("jwt_secret_key", None)  # TODO: decode to bytes might be needed
+    DB_ADDR = ""
+    DB_ALIAS = "user-db"


### PR DESCRIPTION
**What it does**
remove the falsely added test db info
Move config args to config.py and .env file
Add python-dotenv lib

**What to look at**
All configs in config.py
The new db_addr is now defined in .env file and read by config.py
