### PR TITLE
new `prospects_auto_add_to_step` method to add prospects to certain step

### DIFF
--- a/server/api/campaign_handler.py
+++ b/server/api/campaign_handler.py
@@ -49,7 +49,8 @@ campaign_entry_allow_methods = {
     "steps_add": new_schema("content", "subject"),
     "steps_edit": new_schema("content", "subject", step_index=get_schema("integer")),
     "steps_send": new_schema(step_index=get_schema("integer")),
-    "prospects_add": new_schema(prospect_ids=get_schema("array"))
+    "prospects_add": new_schema(prospect_ids=get_schema("array")),
+    "prospects_auto_add_to_step": new_schema(step_index=get_schema("integer"))
 }
 
 
@@ -69,6 +70,7 @@ def campaign_entry(campaign_id, method_name):
             steps_edit
             steps_send
             prospects_add
+            prospects_auto_add_to_step
     Returns:
         {"status":True, "error_code":0,"response":jsonified_RETURN_FROM_CORRESPONDING_METHOD}
         if fail, the return will be in the format

--- a/server/db/model/campaign_model.py
+++ b/server/db/model/campaign_model.py
@@ -111,7 +111,7 @@ class Campaign(MongoModel):
 
     def prospects_add(self, prospect_ids):
         """
-
+        Add prospects to campaign
         Args:
             prospect_ids: list of str _id of prospects
 
@@ -139,6 +139,35 @@ class Campaign(MongoModel):
         for pid in prospect_ids:
             self.steps[step_index].prospects.append(ObjectId(pid))
         self.save()
+
+    def prospects_auto_add_to_step(self, step_index):
+        """
+        Route: to move prospects to a step
+        All prospects in previous step that did receive an email, is moved to the next step
+        For the first step, all prospects that are not part of any step are moved to the first step
+        Args:
+            step_index:
+
+        Returns:
+
+        """
+        if step_index == 0:
+            # all prospects that are not part of any step are moved to the first step
+            for each_p in self.prospects:
+                exist = False
+                for each_step in self.steps:
+                    if each_p in each_step.prospects:
+                        exist = True
+                        break
+                if not exist:
+                    self.steps[step_index].prospects.append(each_p)
+        else:
+            for each_p in self.steps[step_index-1]:
+                if each_p in self.steps[step_index]:
+                    continue
+                self.steps[step_index].prospects.append(each_p)
+        self.save()
+        return self.steps[step_index].prospects
 
     def steps_send(self, step_index):
         self.creator.gmail_start_webhook()

--- a/server/db/model/user_model.py
+++ b/server/db/model/user_model.py
@@ -267,6 +267,7 @@ class UserProspects(UserBase):
             if prospect_obj['email'] not in own_prospect_emails_set:
                 new_prospects_set.add(tuple(prospect_obj.items()))
 
+        prospect_objs = []
         if len(new_prospects_set) > 0:
             prospect_objs = Prospect.objects.bulk_create(
                 [Prospect(owner=self._id, **dict(prospect_tup)) for prospect_tup in new_prospects_set], retrieve=False)
@@ -274,7 +275,8 @@ class UserProspects(UserBase):
             self.prospects_count += len(prospect_objs)
             self.save()
 
-        return {'new_prospects': len(new_prospects_set), 'dup_prospects': len(prospects_list) - len(new_prospects_set)}
+        return {'new_prospects': len(new_prospects_set), 'dup_prospects': len(prospects_list) - len(new_prospects_set),
+                'prospects_ids': prospect_objs}
 
     def get_prospects(self):
         with no_auto_dereference(Prospect):

--- a/server/test/campaign_handler_test.py
+++ b/server/test/campaign_handler_test.py
@@ -63,6 +63,16 @@ class CampaignHandlerTest(TestBase):
         self.assertTrue(User.get_by_email(fake_json["email"]).campaigns_list()[0].steps[0].to_son().to_dict()[
                             "subject"] == "Title2")
 
+        res = self.api.post("/user/prospects_bulk_append",
+                            json={"prospects_list": [{"email": "email"}, {"email": "email2"}]})
+        print(res.json)
+        res = self.api.post("/campaign/{}/prospects_add".format(_id),
+                            json={"prospect_ids": res.json["response"]["prospects_ids"]})
+        print(res.json)
+        res = self.api.post("/campaign/{}/prospects_auto_add_to_step".format(_id),
+                            json={"step_index": 0})
+        print(res.json)
+
     def tearDown(self):
         User.objects.raw({"email": {"$regex": r".*@test\.test"}}).delete()
         User.objects.raw({"email": "a@b.com"}).delete()

--- a/server/worker/send_gmail.py
+++ b/server/worker/send_gmail.py
@@ -40,7 +40,7 @@ def send_gmail_worker(user_id, campaign_id, step_index):
     status_dict = {}
 
     def status_update(each_p, status, value):
-        step.prospects_email_status[str(each._id)] = value
+        step.prospects_email_status[str(each_p._id)] = value
         status_dict[str(each_p._id)] = status
 
     def update_thread_id(prospect, thread_id):
@@ -59,6 +59,9 @@ def send_gmail_worker(user_id, campaign_id, step_index):
 
     count = 0
     for each in step.prospects:
+        # Skip prospects that already receive the email
+        if str(each._id) in step.prospects_email_status and step.prospects_email_status[str(each._id)] > 0:
+            continue
         email_text = campaign.steps_email_replace_keyword(step.email, each)
         msg = create_message(each.email, campaign.subject, email_text)
         # Set threadId to keep the email in a conversation in the same campagin


### PR DESCRIPTION
**What it does**
Route: to move prospects to a step
All prospects in previous step that did receive an email, is moved to the next step
For the first step, all prospects that are not part of any step are moved to the first step

Modify the sending emails route to send emails to prospects in a step that hasn't received an email yet

**What to look at**
New `prospects_auto_add_to_step` method in campaign_entry


**What to avoid**
The action is not efficient, can be improve later
